### PR TITLE
2.0 package stuff

### DIFF
--- a/cleanup.sh
+++ b/cleanup.sh
@@ -5,7 +5,6 @@ set -e
 #apt-get remove -qy software-properties-common
 apt-get remove -qy cython
 apt-get remove -qy gcc
-apt-get remove -qy git
 apt-get remove -qy perl
 
 apt-get autoremove -qy

--- a/setup.sh
+++ b/setup.sh
@@ -9,7 +9,7 @@ apt-get update -qq
 
 apt-get -qy install juju-2.0
 apt-get -qy install byobu vim charm-tools openssh-client
-apt-get -qy install virtualenvwrapper python-dev cython git
+apt-get -qy install virtualenvwrapper python-dev cython
 
 useradd -m ubuntu
 echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/juju-users


### PR DESCRIPTION
@johnsca noticed that the devel branch did not have juju installed.

According to the logs removing the "git" package we uninstall charm-tools which uninstalls juju2.
