### PR TITLE
Patches charmbox #36

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,7 @@ apt-get -qy install juju-2.0
 apt-get -qy install byobu vim charm-tools openssh-client sudo
 apt-get -qy install virtualenvwrapper python-dev cython
 
-useradd -m ubuntu
+useradd -m ubuntu -s /bin/bash
 echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/juju-users
 
 HOME=/home/ubuntu


### PR DESCRIPTION
The ubuntu user is getting added to the system with a default shell of
/bin/sh which causes some assumptions grief. We're expecting things to
be loaded via .bash_profile/.bashrc - this is not the case when using
/bin/sh

While the run script does specify bash, this does not ring true when
using multiplexers like byobu or tmux
