### PR TITLE
move VOLUME bits to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,19 @@
 FROM ubuntu:16.04
 MAINTAINER Charles Butler <charles.butler@canonical.com>
 
-VOLUME ["/home/ubuntu/.local/share/juju", "/home/ubuntu/trusty", "/home/ubuntu/xenial", "/home/ubuntu/layers", "/home/ubuntu/interfaces", "/home/ubuntu/builds"]
+RUN useradd -m ubuntu -s /bin/bash
+
+RUN mkdir -p \
+  /home/ubuntu/.local/share/juju \
+  /home/ubuntu/builds \
+  /home/ubuntu/interfaces \
+  /home/ubuntu/layers \
+  /home/ubuntu/trusty \
+  /home/ubuntu/xenial
+
+RUN chown -R ubuntu:ubuntu /home/ubuntu
+
+VOLUME ["/home/ubuntu/.local/share/juju", "/home/ubuntu/builds", "/home/ubuntu/interfaces", "/home/ubuntu/layers", "/home/ubuntu/trusty", "/home/ubuntu/xenial"]
 
 ADD setup.sh /setup.sh
 ADD run.sh /run.sh

--- a/run.sh
+++ b/run.sh
@@ -3,5 +3,4 @@ set -e
 
 export HOME=/home/ubuntu
 cd $HOME
-chown ubuntu:ubuntu $HOME/.local/share/juju
 sudo -u ubuntu ssh-agent /bin/bash

--- a/setup.sh
+++ b/setup.sh
@@ -13,7 +13,6 @@ apt-get -qy install juju-2.0
 apt-get -qy install byobu vim charm-tools openssh-client sudo
 apt-get -qy install virtualenvwrapper python-dev cython
 
-useradd -m ubuntu -s /bin/bash
 echo "ubuntu ALL=(ALL) NOPASSWD:ALL" > /etc/sudoers.d/juju-users
 
 HOME=/home/ubuntu
@@ -27,16 +26,6 @@ export INTERFACE_PATH=${HOME}/interfaces
 export LAYER_PATH=${HOME}/layers
 echo 'welcome to juju 2.0'
 EOF
-
-# Create volume export paths
-mkdir -p /home/ubuntu/.local/share/juju
-mkdir /home/ubuntu/trusty
-mkdir /home/ubuntu/xenial
-mkdir /home/ubuntu/layers
-mkdir /home/ubuntu/interfaces
-mkdir /home/ubuntu/builds
-
-chown -R ubuntu:ubuntu ${HOME}
 
 # Cleanup Script moved here
 apt-get remove -qy cython gcc


### PR DESCRIPTION
Creating and chowning the VOLUME directories inside setup.sh and run.sh was
not working as expected. If these dirs were not owned by 'ubuntu', some users
had problems downstream in charmbox:

https://github.com/juju-solutions/charmbox/issues/57

When these dirs were chown'd in run.sh, we again had problems downstream:

https://github.com/juju-solutions/charmbox/issues/60

According to the followin article, creation and ownership of VOLUME dirs
needs to happen before VOLUME is specified in the Dockerfile (see
'Permissions and Ownership' heading):

http://container-solutions.com/understanding-volumes-docker/

This commit moves the VOLUME-related bits from [setup|run].sh into Dockerfile.
I can confirm this addresses both downstream issues mentioned above.
